### PR TITLE
Downgrade target to es2021 to prevent emitting blank class fields

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bls-wallet-signer",
-  "version": "0.3.6",
+  "version": "0.3.7",
   "description": "Client-side tool for signing bls transaction data",
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,7 +4,7 @@
 
     /* Basic Options */
     // "incremental": true,                         /* Enable incremental compilation */
-    "target": "esnext",                             /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017', 'ES2018', 'ES2019', 'ES2020', 'ES2021', or 'ESNEXT'. */
+    "target": "es2021",                             /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017', 'ES2018', 'ES2019', 'ES2020', 'ES2021', or 'ESNEXT'. */
     "module": "commonjs",                           /* Specify module code generation: 'none', 'commonjs', 'amd', 'system', 'umd', 'es2015', 'es2020', or 'ESNext'. */
     // "lib": [],                                   /* Specify library files to be included in the compilation. */
     // "allowJs": true,                             /* Allow javascript files to be compiled. */


### PR DESCRIPTION
Related to https://github.com/jzaki/bls-wallet-extension/issues/7